### PR TITLE
Fix: App/Docker Build Failed (BUG-8287) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,10 @@ yarn-error.log*
 
 # Frontend
 app
+
+# Virtual env
+.venv 
+.env
+
+# Ini files for development
+development.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # get python base
 FROM python:3.10-slim-bookworm
-ARG PIP_ACCESS_TOKEN
+#ARG PIP_ACCESS_TOKEN
 # use the same userid in the container as you have outside of the container
 # this avoids permission conflicts when mounting volumes 
 # as default use 1000/1000 as UID/GID, but they can be changed at build time if required

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,11 @@ install_requires =
     docopt
     gunicorn
     pyramid
-    numpy==2.*
+    numpy>=1.26,<2.0
     sqlalchemy==2.*
     transaction
     mako
-    pandas==2.1.4
+    pandas
     pypugjs
     psycopg2-binary
     pyramid_debugtoolbar


### PR DESCRIPTION
# Ticket
1. BUG 8287 - Application (Via Docker) cannot be built

# Root Cause:
Dependency version conflicts:
- pandas==2.1.4 require compatible version of numpy
-  the previous strict versioning for numpy==2.* cause failed 

# Solutions:
- loosened numpy versioning from numpy==2.*  to  numpy>=1.26,<2.0 
- pandas compatibility resolve by pip automatically deciding

# Additional changes:
- commented out ARG PIP_ACCESS_TOKEN for this stage of development (it triggered warning while building docker image)
- added additional line in .gitignore for local development (.venv, .env and development.ini for local test database)

# Test performed:
- docker build -t pyramid_app_caseinterview .   ==> success
-  docker run --rm -p 6543:6543 pyramid_app_caseinterview ==> success

