### PR TITLE
Fix: Timeseries 404 not found error and Datetime format error (BUG-8287;8288)

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -23,7 +23,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": q.datetime.isoformat() if q.datetime else None,
                 "value": q.value,
             }
             for q in query.all()


### PR DESCRIPTION
# Tickets
3. BUG 8287 - Timeseries API: 404 Not Found Error
4. BUG 8288 - Timeseries API: Datetime Format Error

# Descriptions
There are two main issues:
- user receive a 404 not found error when attempting to access Timeseries API endpoint.
- When the endpoint is accessible, a datetime serialization error occurs (datetime object is not JSON serializable).

# Root causes:
- API 404 not found error caused by the typo in user request. The correct endpoint is /api/v1/timeseries, but users were calling /api/v1/timeserie.
- Datetime Format Error caused by the nature of datetime format in query object cannot be directly serialized to JSON.

# Solutions:
- For API 404 not found error:
  - Short-term: Clearly communicate that  user has misspelled the API endpoint and provide the correct API endpoint informatively.
  - Long-term: I propose a redirect routes feature or aliasing for this misspelled issues, so we can keep the good practice of RESTful API where the endpoint should be in plural nouns but also automatically handle non technical user misspelled issues.

- For Datetime Format Error:
  - Short-term:   Apply .isoformat() in query datetime object in API view, so they can be serialized correctly following ISO 8601.
  - Long-term: I proposed modular utilities to perform JSON serializing for specific query objects so we don't have to repeat this process in future API endpoint that return query datetime objects.

# Test Performed:
- call for `/api/v1/timeseries` has succesfully return the correct JSON objects.

<img width="2758" height="1072" alt="Screenshot from 2025-08-21 22-40-36" src="https://github.com/user-attachments/assets/f42ad15d-d196-4c71-8139-062feb9582d5" />
