### PR TITLE
Feature: Timeseries date filter (BACKLOG-8291)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # get python base
 FROM python:3.10-slim-bookworm
-ARG PIP_ACCESS_TOKEN
+#ARG PIP_ACCESS_TOKEN
 # use the same userid in the container as you have outside of the container
 # this avoids permission conflicts when mounting volumes 
 # as default use 1000/1000 as UID/GID, but they can be changed at build time if required

--- a/pyramid_app_caseinterview/filters/__init__.py
+++ b/pyramid_app_caseinterview/filters/__init__.py
@@ -1,0 +1,1 @@
+"""Filter Utilities Module"""

--- a/pyramid_app_caseinterview/filters/services.py
+++ b/pyramid_app_caseinterview/filters/services.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Query
+
+from typing import Dict, Type
+from pyramid_app_caseinterview.filters.timeseries import timeseries_datetime_filter
+
+def get_filtered_query(
+    model: Type,    
+    query: Query ,
+    filters: Dict[str, str],
+    filter_type: str = "timeseries_datetime_filter"
+    ):
+    """
+    Modular filter dispatcher for any model.
+    """
+    filter_collections = {
+        "timeseries_datetime_filter": timeseries_datetime_filter,
+        # Place other filters here
+    }
+
+    filter_func = filter_collections.get(filter_type)
+    if not filter_func:
+        raise KeyError(f"Invalid filter type '{filter_type}'.")
+
+    return filter_func(model, query, filters)

--- a/pyramid_app_caseinterview/filters/timeseries.py
+++ b/pyramid_app_caseinterview/filters/timeseries.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from sqlalchemy.orm import Query
+from typing import Dict, Type
+
+
+def timeseries_datetime_filter(model: Type, query: Query, filters: Dict[str, str]):
+    """Datetime filter by start_date and end_date from filters dict."""
+    start_date = filters.get("start_date")
+    end_date = filters.get("end_date")
+
+    if start_date:
+        try:
+            dt_start = datetime.fromisoformat(start_date)
+            query = query.filter(model.datetime >= dt_start)
+        except ValueError:
+            raise ValueError(f"Invalid start_date format {start_date}. "
+                             f"Expected ISO format YYYY-MM-DDThh:mm:ss for full datetime "
+                             f"or YYYY-MM-DD for date resolution only.")
+
+    if end_date:
+        try:
+            dt_end = datetime.fromisoformat(end_date)
+            query = query.filter(model.datetime <= dt_end)
+        except ValueError:
+            raise ValueError(f"Invalid end_date format {end_date}. "
+                             f"Expected ISO format YYYY-MM-DDThh:mm:ss for full datetime "
+                             f"or YYYY-MM-DD for date resolution only.")
+
+    return query

--- a/pyramid_app_caseinterview/scripts/generate_fake_data.py
+++ b/pyramid_app_caseinterview/scripts/generate_fake_data.py
@@ -71,7 +71,7 @@ def generate_depthseries_data(num_records:int):
     """
     records = []
     for i in range(num_records):
-        # Depth range from 0 to 50 masl
+        # Depth range from 0 to 50 meters
         depth = i * 50 / (num_records - 1) if num_records > 1 else 0
         # Simulate cone tip resistance (qc, MPa) with realistic variation (2 to 30 Mpa)
         qc = np.clip(np.random.normal(15,5), 2, 30)

--- a/pyramid_app_caseinterview/scripts/generate_fake_data.py
+++ b/pyramid_app_caseinterview/scripts/generate_fake_data.py
@@ -1,0 +1,140 @@
+"""
+Generate fake realistic data into database.
+
+In this example we simulated cone tip resistance for depthseries
+and wind speed for the timeseries.
+
+Usage:
+  pyramid_app_caseinterview_generate_fake_data <inifile> [options]
+  pyramid_app_caseinterview_generate_fake_data --help
+
+Options:
+  -h --help                 Show this screen.
+  -o --options=LIST         Comma-separated list of key=value pairs overwriting default setting in initfile.
+  --clear-data              Clear existing timeseries and depthseries data before generating new data.
+  --num-timeseries=NUM      Number of timeseries records to generate [default: 120].
+  --num-depthseries=NUM     Number of depthseries records to generate [default: 50].
+"""
+
+import logging
+import os 
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import numpy as np
+import transaction
+from docopt import docopt
+from pyramid.paster import get_appsettings, setup_logging
+
+from pyramid_app_caseinterview import get_config
+from pyramid_app_caseinterview.models.depthseries import Depthseries
+from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.models import (
+    get_engine,
+    get_session_factory,
+    get_tm_session)
+
+logger = logging.getLogger(__name__)
+
+ALEMBIC_INI = os.path.join(os.path.dirname(__file__), "..", "..", "alembic.ini")
+
+def generate_timeseries_data(num_records: int):
+    """Generate fake realistic wind speed timeseries data.
+    
+    Hourly wind speed data (0–25 m/s, mean 10 m/s, std 5 m/s)
+    starting from `num_records` hours before the current time, progressing forward.
+    
+    """
+    now_time = datetime.now() - timedelta(hours=num_records)
+    records = []
+    for i in range(num_records):
+        # Generate hourly timestamps
+        timestamp = now_time + timedelta(hours=i)
+        # Simulate wind speed (m/s) with realistic variation (0 to 25 m/s)
+        wind_speed = np.clip(np.random.normal(10,5), 0, 25)
+        record = Timeseries(
+            id=uuid4(),
+            datetime=timestamp,
+            value=round(wind_speed, 2)                  
+        )
+
+        records.append(record)
+    
+    return records
+
+
+def generate_depthseries_data(num_records:int):
+    """Generate fake cone tip resistance depthseries data.
+    
+    Cone tip resistance (qc, 2–30 MPa, mean 15 MPa, std 5 MPa)
+    for depths evenly spaced from 0 to 50 meters
+    """
+    records = []
+    for i in range(num_records):
+        # Depth range from 0 to 50 masl
+        depth = i * 50 / (num_records - 1) if num_records > 1 else 0
+        # Simulate cone tip resistance (qc, MPa) with realistic variation (2 to 30 Mpa)
+        qc = np.clip(np.random.normal(15,5), 2, 30)
+        record = Depthseries(
+            id=uuid4(),
+            depth=round(depth, 2),
+            value=round(qc, 2)
+        )
+        records.append(record)
+    
+    return records
+
+def main(argv=None):
+    """Generate fake data for timeseries and depthseries tables."""
+    args = docopt(__doc__, argv=argv)
+    setup_logging(args["<inifile>"])
+    settings = get_appsettings(args["<inifile>"])
+    if args["--options"]:
+        settings.update(
+            {
+                k.strip(): v.strip()
+                for kv in args["--options"].split(",")
+                for k, v in kv.split("=")
+            }
+        )
+    
+    config = get_config(settings=settings).get_settings()
+    engine = get_engine(config)
+    
+    session_factory = get_session_factory(engine)
+
+    try:
+        num_timeseries = int(args["--num-timeseries"])
+        num_depthseries = int(args["--num-depthseries"])
+
+        if num_timeseries <=0 and num_depthseries <=0:
+            logger.error("Number of records must be positive")
+            raise ValueError("Number of records must be positive")
+    except ValueError as e:
+        logger.error(f"Invalid input: {e}")
+                         
+
+    with transaction.manager:
+        session = get_tm_session(session_factory, transaction.manager)
+        if args["--clear-data"]:
+            logger.warning("Clearing existing timeseries and depthseries data!")
+            session.query(Timeseries).delete()
+            session.query(Depthseries).delete()
+        
+        # Generate and insert timeseries data
+        logger.info(f"Generating {num_timeseries} timeseries records...")
+        timeseries_records = generate_timeseries_data(num_timeseries)
+        session.add_all(timeseries_records)
+
+        # Generate and insert depthseries data
+        logger.info(f"Generating {num_depthseries} depthseries records...")
+        depthseries_records = generate_depthseries_data(num_depthseries)
+        session.add_all(depthseries_records)
+
+        logger.info("Committing data to database...")
+
+    logger.info("Finished generating fake data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
+++ b/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
@@ -2,12 +2,12 @@
 Ingest Depthseries data form CSV file into database with integrity and clean checks.
 
 Usage:
-  pyramid_app_caseinterview_ingest_depthseries <inifile> --csv-file=<filename> [options]
-  pyramid_app_caseinterview_ingest_depthseries --help
+  pyramid_app_caseinterview_ingest_depthseries_data <inifile> --csv-file=<filename> [options]
+  pyramid_app_caseinterview_ingest_depthseries_data --help
 
 Options:
   -h --help                Show this screen.
-  -o --options=LIST         Comma-separated list of key=value pairs overwriting default setting in initfile.
+  -o --options=LIST        Comma-separated list of key=value pairs overwriting default setting in initfile.
   --csv-file=<filename>    Name of CSV file located in `datadirectory` (from .ini).
   --clear-data             Clear existing depthseries data before ingestion.
 

--- a/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
+++ b/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
@@ -1,0 +1,131 @@
+"""
+Ingest Depthseries data form CSV file into database with integrity and clean checks.
+
+Usage:
+  pyramid_app_caseinterview_ingest_depthseries <inifile> --csv-file=<filename> [options]
+  pyramid_app_caseinterview_ingest_depthseries --help
+
+Options:
+  -h --help                Show this screen.
+  -o --options=LIST         Comma-separated list of key=value pairs overwriting default setting in initfile.
+  --csv-file=<filename>    Name of CSV file located in `datadirectory` (from .ini).
+  --clear-data             Clear existing depthseries data before ingestion.
+
+"""
+
+import csv
+import logging
+import os
+from uuid import uuid4
+
+import transaction
+from docopt import docopt
+from pyramid.paster import get_appsettings, setup_logging
+
+from pyramid_app_caseinterview import get_config
+from pyramid_app_caseinterview.models import (
+    depthseries,
+    get_engine,
+    get_session_factory,
+    get_tm_session,
+)
+
+logger = logging.getLogger(__name__)
+
+def validate_and_clean(records):
+    """Validate and clean depthseries records data."""
+    recorded_depths = set()    
+    cleaned = []
+
+    for row in records:
+        depth = row["depth"]
+        value = row["value"]
+
+        if depth in recorded_depths:
+            logger.warning(f"Duplicate depth {depth} found, skipping row {row}")
+            continue
+
+        recorded_depths.add(depth)
+        cleaned.append(
+            depthseries.Depthseries(
+                id = uuid4(),
+                depth=depth,
+                value = value,
+            )
+        )
+    
+    return cleaned
+
+
+def load_csv(file_path):
+    """Read depthseries data from CSV input file"""
+    records = []
+    with open(file_path, newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            try:
+                depth = float(row["depth"])
+                value = float(row["value"])
+                records.append({
+                    "depth": depth,
+                    "value": value
+                })
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Skipping invalid row {row}: {e}")
+
+    return records
+
+
+def main(argv=None):
+    """Ingest depthseries data from CSV file"""
+    args = docopt(__doc__, argv=argv)
+    setup_logging(args["<inifile>"])
+    settings = get_appsettings(args["<inifile>"])
+    if args["--options"]:
+        settings.update(
+
+            {
+                k.strip(): v.strip()
+                for kv in args["--options"].split(",")
+                for k, v in kv.split("=")
+            }
+        )
+    
+    config = get_config(settings=settings).get_settings()
+    engine = get_engine(config)
+
+    session_factory = get_session_factory(engine)
+
+    datadir = settings.get("datadirectory", "data")
+    csv_file = args["--csv-file"]
+    csv_path = os.path.join(datadir, csv_file)
+
+    if not os.path.exists(csv_path):
+        logger.error(f"CSV file {csv_path} does not exist.")
+        return 1
+    
+    with transaction.manager:
+        session = get_tm_session(session_factory, transaction.manager)
+        if args["--clear-data"]:
+            logger.warning("Clearing existing depthseries data!")
+            session.query(depthseries.Depthseries).delete()
+
+        # Load CSV
+        logger.info(f"Loading csv file {csv_path}...")
+        raw_records = load_csv(csv_path)
+
+        # validate and clean records
+        cleaned_records = validate_and_clean(raw_records)
+
+        logger.info(f"Inserting {len(cleaned_records)} depthseries records...")
+        session.add_all(cleaned_records)
+
+    logger.info("CSV ingestion complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -38,26 +38,6 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        # ## API layer fixes for duplication problems
-        # # Option 1: By keeping only the first occurrence of each depth
-        # query = self.session.query(Depthseries)
-        # recorded_depths = set()
-        # cleaned_records = []
-        # for q in query.all():
-        #     if q.depth in recorded_depths:
-        #         continue 
-        #     recorded_depths.add(q.depth)
-        #     cleaned_records.append(
-        #         {
-        #             "id": str(q.id),
-        #             "depth": q.depth,
-        #             "value": q.value
-        #         }
-        #     )
-
-        # return cleaned_records
-    
-        # Option 2: By leveraging sqlalchemy functionalities at query time
         sub_query = (
             self.session.query(
                 Depthseries.id,
@@ -69,10 +49,11 @@ class API(View):
                 )
                 .label("rn")
             )
+            .filter(Depthseries.value.isnot(None))
             .subquery()
         )
 
-        # Pick only the first fow
+        # Pick only the first row
         query = self.session.query(
             sub_query.c.id,
             sub_query.c.depth,
@@ -84,6 +65,6 @@ class API(View):
                 "id": str(q.id),
                 "depth": q.depth,
                 "value": q.value
-                }
+            }
                 for q in query.all()
-            ]
+        ]

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -2,9 +2,11 @@
 
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPBadRequest
 
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.filters.services import get_filtered_query
 
 from sqlalchemy import func
 
@@ -22,13 +24,23 @@ class API(View):
     )
     def timeseries_api(self):
         query = self.session.query(Timeseries)
+
+        try:
+            query = get_filtered_query(Timeseries,
+                                       query,
+                                       self.request.GET,
+                                       filter_type="timeseries_datetime_filter"
+                                    )
+            
+        except ValueError as e:
+            raise HTTPBadRequest(json_body={"Error": str(e)})
+
         return [
             {
                 "id": str(q.id),
                 "datetime": q.datetime.isoformat() if q.datetime else None,
                 "value": q.value,
-            }
-            for q in query.all()
+            }   for q in query.all()
         ]
 
     @view_config(

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": q.datetime.isoformat() if q.datetime else None,
                 "value": q.value,
             }
             for q in query.all()
@@ -36,12 +38,52 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        # ## API layer fixes for duplication problems
+        # # Option 1: By keeping only the first occurrence of each depth
+        # query = self.session.query(Depthseries)
+        # recorded_depths = set()
+        # cleaned_records = []
+        # for q in query.all():
+        #     if q.depth in recorded_depths:
+        #         continue 
+        #     recorded_depths.add(q.depth)
+        #     cleaned_records.append(
+        #         {
+        #             "id": str(q.id),
+        #             "depth": q.depth,
+        #             "value": q.value
+        #         }
+        #     )
+
+        # return cleaned_records
+    
+        # Option 2: By leveraging sqlalchemy functionalities at query time
+        sub_query = (
+            self.session.query(
+                Depthseries.id,
+                Depthseries.depth,
+                Depthseries.value,
+                func.row_number()
+                .over(
+                    partition_by=Depthseries.depth,
+                )
+                .label("rn")
+            )
+            .subquery()
+        )
+
+        # Pick only the first fow
+        query = self.session.query(
+            sub_query.c.id,
+            sub_query.c.depth,
+            sub_query.c.value
+        ).filter(sub_query.c.rn == 1)
+
         return [
             {
                 "id": str(q.id),
                 "depth": q.depth,
-                "value": q.value,
-            }
-            for q in query.all()
-        ]
+                "value": q.value
+                }
+                for q in query.all()
+            ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ paste.app_factory =
 
 console_scripts =
     pyramid_app_caseinterview_initialize_db = pyramid_app_caseinterview.scripts.initializedb:main
+    pyramid_app_caseinterview_generate_fake_data = pyramid_app_caseinterview.scripts.generate_fake_data:main
+    pyramid_app_caseinterview_ingest_depthseries_data = pyramid_app_caseinterview.scripts.ingest_data_depthseries:main
 
 [options]
 packages = find:
@@ -32,11 +34,11 @@ install_requires =
     docopt
     gunicorn
     pyramid
-    numpy==2.*
+    numpy>=1.26,<2.0
     sqlalchemy==2.*
     transaction
     mako
-    pandas==2.1.4
+    pandas
     pypugjs
     psycopg2-binary
     pyramid_debugtoolbar


### PR DESCRIPTION
# Ticket 
7. PRODUCT BACKLOG ITEM 8291 – Timeseries API: Add Date Filtering from URL Query Parameter

# Description
Users want to filter the data returned by the https://caseinterview.data-dev.test.com/api/v1/timeseries endpoint based on date ranges. This will help them get only the data they need instead of downloading everything.

# Implementation
For this feature, I propose robust and modular `filters` where future filter will be developed and utilized from there.  For the date-based filter specific to this ticket, the API now accepts start_date and end_date as query parameters.

# Key Additions:
- New modular `filters` package: Centralized filtering logic allowing for extensibility beyond just datetime filters.
- Timeseries API integration: The get_filtered_query() service parses query parameters and applies filters based on the specified filter_type. Here’s how it's integrated:

```python
query = get_filtered_query(
    Timeseries,
    query,
    self.request.GET,
    filter_type="timeseries_datetime_filter"
)
```

- Query parameter example:
```http
GET /api/v1/timeseries?start_date=2025-08-21&end_date=2025-12-25
````

# Error Handling
If the user provides an invalid date format (e.g., 2025-12-2r), the API responds with a descriptive error message:

```json
{
  "Error": "Invalid end_date format 2025-12-2r. Expected ISO format YYYY-MM-DDThh:mm:ss for full datetime or YYYY-MM-DD for date resolution only."
}
```
This response will guide user on proper formatting using ISO 8601 standards.

# Changes Summary 
- Developed a new reusable filtering module from scratch.
- Integrated date filtering logic into the /timeseries endpoint using the modular filter system.