### PR TITLE
Feature: Add Depthseries download data endpoint (BACKLOG-8293)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # get python base
 FROM python:3.10-slim-bookworm
-ARG PIP_ACCESS_TOKEN
+#ARG PIP_ACCESS_TOKEN
 # use the same userid in the container as you have outside of the container
 # this avoids permission conflicts when mounting volumes 
 # as default use 1000/1000 as UID/GID, but they can be changed at build time if required

--- a/pyramid_app_caseinterview/filters/__init__.py
+++ b/pyramid_app_caseinterview/filters/__init__.py
@@ -1,0 +1,1 @@
+"""Filter Utilities Module"""

--- a/pyramid_app_caseinterview/filters/depthseries.py
+++ b/pyramid_app_caseinterview/filters/depthseries.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Query
+from typing import Dict, Type
+
+
+def depthseries_depth_filter(model: Type, query: Query, filters: Dict[str, str]):
+    """Depthseries filter by start_depth and end_depth from filters dict."""
+    start_depth = filters.get("start_depth")
+    end_depth = filters.get("end_depth")
+
+    if start_depth:
+        try:
+            start_depth = float(start_depth)
+            query = query.filter(model.depth >= start_depth)
+        except ValueError:
+            raise ValueError(f"Invalid start_depth {start_depth}.")
+
+    if end_depth:
+        try:
+            end_depth = float(end_depth)
+            query = query.filter(model.depth <= end_depth)
+        except ValueError:
+            raise ValueError(f"Invalid end_depth format {end_depth}.")
+
+    return query

--- a/pyramid_app_caseinterview/filters/services.py
+++ b/pyramid_app_caseinterview/filters/services.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Query
+
+from typing import Dict, Type
+from pyramid_app_caseinterview.filters.timeseries import timeseries_datetime_filter
+
+def get_filtered_query(
+    model: Type,    
+    query: Query ,
+    filters: Dict[str, str],
+    filter_type: str = "timeseries_datetime_filter"
+    ):
+    """
+    Modular filter dispatcher for any model.
+    """
+    filter_collections = {
+        "timeseries_datetime_filter": timeseries_datetime_filter,
+        # Place other filters here
+    }
+
+    filter_func = filter_collections.get(filter_type)
+    if not filter_func:
+        raise KeyError(f"Invalid filter type '{filter_type}'.")
+
+    return filter_func(model, query, filters)

--- a/pyramid_app_caseinterview/filters/services.py
+++ b/pyramid_app_caseinterview/filters/services.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Query
 
 from typing import Dict, Type
 from pyramid_app_caseinterview.filters.timeseries import timeseries_datetime_filter
+from pyramid_app_caseinterview.filters.depthseries import depthseries_depth_filter
 
 def get_filtered_query(
     model: Type,    
@@ -14,7 +15,7 @@ def get_filtered_query(
     """
     filter_collections = {
         "timeseries_datetime_filter": timeseries_datetime_filter,
-        # Place other filters here
+        "depthseries_depth_filter": depthseries_depth_filter
     }
 
     filter_func = filter_collections.get(filter_type)

--- a/pyramid_app_caseinterview/filters/timeseries.py
+++ b/pyramid_app_caseinterview/filters/timeseries.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from sqlalchemy.orm import Query
+from typing import Dict, Type
+
+
+def timeseries_datetime_filter(model: Type, query: Query, filters: Dict[str, str]):
+    """Datetime filter by start_date and end_date from filters dict."""
+    start_date = filters.get("start_date")
+    end_date = filters.get("end_date")
+
+    if start_date:
+        try:
+            dt_start = datetime.fromisoformat(start_date)
+            query = query.filter(model.datetime >= dt_start)
+        except ValueError:
+            raise ValueError(f"Invalid start_date format {start_date}. "
+                             f"Expected ISO format YYYY-MM-DDThh:mm:ss for full datetime "
+                             f"or YYYY-MM-DD for date resolution only.")
+
+    if end_date:
+        try:
+            dt_end = datetime.fromisoformat(end_date)
+            query = query.filter(model.datetime <= dt_end)
+        except ValueError:
+            raise ValueError(f"Invalid end_date format {end_date}. "
+                             f"Expected ISO format YYYY-MM-DDThh:mm:ss for full datetime "
+                             f"or YYYY-MM-DD for date resolution only.")
+
+    return query

--- a/pyramid_app_caseinterview/routes.py
+++ b/pyramid_app_caseinterview/routes.py
@@ -11,3 +11,4 @@ def includeme(config):
     config.add_route("timeseries", "/api/v1/timeseries")
     config.add_route("depthseries", "/api/v1/depthseries")
     config.add_route("activity", "/api/v1/activity")
+    config.add_route("download_depthseries", "/api/v1/download/depthseries")

--- a/pyramid_app_caseinterview/scripts/generate_fake_data.py
+++ b/pyramid_app_caseinterview/scripts/generate_fake_data.py
@@ -71,7 +71,7 @@ def generate_depthseries_data(num_records:int):
     """
     records = []
     for i in range(num_records):
-        # Depth range from 0 to 50 masl
+        # Depth range from 0 to 50 meters
         depth = i * 50 / (num_records - 1) if num_records > 1 else 0
         # Simulate cone tip resistance (qc, MPa) with realistic variation (2 to 30 Mpa)
         qc = np.clip(np.random.normal(15,5), 2, 30)

--- a/pyramid_app_caseinterview/scripts/generate_fake_data.py
+++ b/pyramid_app_caseinterview/scripts/generate_fake_data.py
@@ -1,0 +1,140 @@
+"""
+Generate fake realistic data into database.
+
+In this example we simulated cone tip resistance for depthseries
+and wind speed for the timeseries.
+
+Usage:
+  pyramid_app_caseinterview_generate_fake_data <inifile> [options]
+  pyramid_app_caseinterview_generate_fake_data --help
+
+Options:
+  -h --help                 Show this screen.
+  -o --options=LIST         Comma-separated list of key=value pairs overwriting default setting in initfile.
+  --clear-data              Clear existing timeseries and depthseries data before generating new data.
+  --num-timeseries=NUM      Number of timeseries records to generate [default: 120].
+  --num-depthseries=NUM     Number of depthseries records to generate [default: 50].
+"""
+
+import logging
+import os 
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import numpy as np
+import transaction
+from docopt import docopt
+from pyramid.paster import get_appsettings, setup_logging
+
+from pyramid_app_caseinterview import get_config
+from pyramid_app_caseinterview.models.depthseries import Depthseries
+from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.models import (
+    get_engine,
+    get_session_factory,
+    get_tm_session)
+
+logger = logging.getLogger(__name__)
+
+ALEMBIC_INI = os.path.join(os.path.dirname(__file__), "..", "..", "alembic.ini")
+
+def generate_timeseries_data(num_records: int):
+    """Generate fake realistic wind speed timeseries data.
+    
+    Hourly wind speed data (0–25 m/s, mean 10 m/s, std 5 m/s)
+    starting from `num_records` hours before the current time, progressing forward.
+    
+    """
+    now_time = datetime.now() - timedelta(hours=num_records)
+    records = []
+    for i in range(num_records):
+        # Generate hourly timestamps
+        timestamp = now_time + timedelta(hours=i)
+        # Simulate wind speed (m/s) with realistic variation (0 to 25 m/s)
+        wind_speed = np.clip(np.random.normal(10,5), 0, 25)
+        record = Timeseries(
+            id=uuid4(),
+            datetime=timestamp,
+            value=round(wind_speed, 2)                  
+        )
+
+        records.append(record)
+    
+    return records
+
+
+def generate_depthseries_data(num_records:int):
+    """Generate fake cone tip resistance depthseries data.
+    
+    Cone tip resistance (qc, 2–30 MPa, mean 15 MPa, std 5 MPa)
+    for depths evenly spaced from 0 to 50 meters
+    """
+    records = []
+    for i in range(num_records):
+        # Depth range from 0 to 50 masl
+        depth = i * 50 / (num_records - 1) if num_records > 1 else 0
+        # Simulate cone tip resistance (qc, MPa) with realistic variation (2 to 30 Mpa)
+        qc = np.clip(np.random.normal(15,5), 2, 30)
+        record = Depthseries(
+            id=uuid4(),
+            depth=round(depth, 2),
+            value=round(qc, 2)
+        )
+        records.append(record)
+    
+    return records
+
+def main(argv=None):
+    """Generate fake data for timeseries and depthseries tables."""
+    args = docopt(__doc__, argv=argv)
+    setup_logging(args["<inifile>"])
+    settings = get_appsettings(args["<inifile>"])
+    if args["--options"]:
+        settings.update(
+            {
+                k.strip(): v.strip()
+                for kv in args["--options"].split(",")
+                for k, v in kv.split("=")
+            }
+        )
+    
+    config = get_config(settings=settings).get_settings()
+    engine = get_engine(config)
+    
+    session_factory = get_session_factory(engine)
+
+    try:
+        num_timeseries = int(args["--num-timeseries"])
+        num_depthseries = int(args["--num-depthseries"])
+
+        if num_timeseries <=0 and num_depthseries <=0:
+            logger.error("Number of records must be positive")
+            raise ValueError("Number of records must be positive")
+    except ValueError as e:
+        logger.error(f"Invalid input: {e}")
+                         
+
+    with transaction.manager:
+        session = get_tm_session(session_factory, transaction.manager)
+        if args["--clear-data"]:
+            logger.warning("Clearing existing timeseries and depthseries data!")
+            session.query(Timeseries).delete()
+            session.query(Depthseries).delete()
+        
+        # Generate and insert timeseries data
+        logger.info(f"Generating {num_timeseries} timeseries records...")
+        timeseries_records = generate_timeseries_data(num_timeseries)
+        session.add_all(timeseries_records)
+
+        # Generate and insert depthseries data
+        logger.info(f"Generating {num_depthseries} depthseries records...")
+        depthseries_records = generate_depthseries_data(num_depthseries)
+        session.add_all(depthseries_records)
+
+        logger.info("Committing data to database...")
+
+    logger.info("Finished generating fake data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyramid_app_caseinterview/scripts/generate_fake_data.py
+++ b/pyramid_app_caseinterview/scripts/generate_fake_data.py
@@ -84,6 +84,7 @@ def generate_depthseries_data(num_records:int):
     
     return records
 
+
 def main(argv=None):
     """Generate fake data for timeseries and depthseries tables."""
     args = docopt(__doc__, argv=argv)

--- a/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
+++ b/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
@@ -2,12 +2,12 @@
 Ingest Depthseries data form CSV file into database with integrity and clean checks.
 
 Usage:
-  pyramid_app_caseinterview_ingest_depthseries <inifile> --csv-file=<filename> [options]
-  pyramid_app_caseinterview_ingest_depthseries --help
+  pyramid_app_caseinterview_ingest_depthseries_data <inifile> --csv-file=<filename> [options]
+  pyramid_app_caseinterview_ingest_depthseries_data --help
 
 Options:
   -h --help                Show this screen.
-  -o --options=LIST         Comma-separated list of key=value pairs overwriting default setting in initfile.
+  -o --options=LIST        Comma-separated list of key=value pairs overwriting default setting in initfile.
   --csv-file=<filename>    Name of CSV file located in `datadirectory` (from .ini).
   --clear-data             Clear existing depthseries data before ingestion.
 

--- a/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
+++ b/pyramid_app_caseinterview/scripts/ingest_data_depthseries.py
@@ -1,0 +1,131 @@
+"""
+Ingest Depthseries data form CSV file into database with integrity and clean checks.
+
+Usage:
+  pyramid_app_caseinterview_ingest_depthseries <inifile> --csv-file=<filename> [options]
+  pyramid_app_caseinterview_ingest_depthseries --help
+
+Options:
+  -h --help                Show this screen.
+  -o --options=LIST         Comma-separated list of key=value pairs overwriting default setting in initfile.
+  --csv-file=<filename>    Name of CSV file located in `datadirectory` (from .ini).
+  --clear-data             Clear existing depthseries data before ingestion.
+
+"""
+
+import csv
+import logging
+import os
+from uuid import uuid4
+
+import transaction
+from docopt import docopt
+from pyramid.paster import get_appsettings, setup_logging
+
+from pyramid_app_caseinterview import get_config
+from pyramid_app_caseinterview.models import (
+    depthseries,
+    get_engine,
+    get_session_factory,
+    get_tm_session,
+)
+
+logger = logging.getLogger(__name__)
+
+def validate_and_clean(records):
+    """Validate and clean depthseries records data."""
+    recorded_depths = set()    
+    cleaned = []
+
+    for row in records:
+        depth = row["depth"]
+        value = row["value"]
+
+        if depth in recorded_depths:
+            logger.warning(f"Duplicate depth {depth} found, skipping row {row}")
+            continue
+
+        recorded_depths.add(depth)
+        cleaned.append(
+            depthseries.Depthseries(
+                id = uuid4(),
+                depth=depth,
+                value = value,
+            )
+        )
+    
+    return cleaned
+
+
+def load_csv(file_path):
+    """Read depthseries data from CSV input file"""
+    records = []
+    with open(file_path, newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            try:
+                depth = float(row["depth"])
+                value = float(row["value"])
+                records.append({
+                    "depth": depth,
+                    "value": value
+                })
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Skipping invalid row {row}: {e}")
+
+    return records
+
+
+def main(argv=None):
+    """Ingest depthseries data from CSV file"""
+    args = docopt(__doc__, argv=argv)
+    setup_logging(args["<inifile>"])
+    settings = get_appsettings(args["<inifile>"])
+    if args["--options"]:
+        settings.update(
+
+            {
+                k.strip(): v.strip()
+                for kv in args["--options"].split(",")
+                for k, v in kv.split("=")
+            }
+        )
+    
+    config = get_config(settings=settings).get_settings()
+    engine = get_engine(config)
+
+    session_factory = get_session_factory(engine)
+
+    datadir = settings.get("datadirectory", "data")
+    csv_file = args["--csv-file"]
+    csv_path = os.path.join(datadir, csv_file)
+
+    if not os.path.exists(csv_path):
+        logger.error(f"CSV file {csv_path} does not exist.")
+        return 1
+    
+    with transaction.manager:
+        session = get_tm_session(session_factory, transaction.manager)
+        if args["--clear-data"]:
+            logger.warning("Clearing existing depthseries data!")
+            session.query(depthseries.Depthseries).delete()
+
+        # Load CSV
+        logger.info(f"Loading csv file {csv_path}...")
+        raw_records = load_csv(csv_path)
+
+        # validate and clean records
+        cleaned_records = validate_and_clean(raw_records)
+
+        logger.info(f"Inserting {len(cleaned_records)} depthseries records...")
+        session.add_all(cleaned_records)
+
+    logger.info("CSV ingestion complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/pyramid_app_caseinterview/utils/__init__.py
+++ b/pyramid_app_caseinterview/utils/__init__.py
@@ -1,0 +1,1 @@
+"File writer package."

--- a/pyramid_app_caseinterview/utils/file_writers.py
+++ b/pyramid_app_caseinterview/utils/file_writers.py
@@ -1,0 +1,27 @@
+import csv 
+from io import StringIO
+from pyramid.response import Response
+
+from sqlalchemy.orm import Query
+
+def write_to_csv(query: Query, header:list, output_name:str = "download.csv"):
+    """Write query rows to CSV file and return as HTT response"""
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(header)
+
+    if not query.all():
+        return Response(
+            "\n".join([",".join(header)]),
+            content_type="text/csv",
+            content_disposition=f"attachment; filename={output_name}"
+        )
+    
+    for row in query.all():
+        writer.writerow([getattr(row, col) for col in header])
+    
+    # Prepare HTTP response object
+    response = Response(body=output.getvalue())
+    response.content_type = "text/csv"
+    response.headers["content-deposition"] = f"attachment; filename={output_name}"
+    return response

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -38,26 +38,6 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        # ## API layer fixes for duplication problems
-        # # Option 1: By keeping only the first occurrence of each depth
-        # query = self.session.query(Depthseries)
-        # recorded_depths = set()
-        # cleaned_records = []
-        # for q in query.all():
-        #     if q.depth in recorded_depths:
-        #         continue 
-        #     recorded_depths.add(q.depth)
-        #     cleaned_records.append(
-        #         {
-        #             "id": str(q.id),
-        #             "depth": q.depth,
-        #             "value": q.value
-        #         }
-        #     )
-
-        # return cleaned_records
-    
-        # Option 2: By leveraging sqlalchemy functionalities at query time
         sub_query = (
             self.session.query(
                 Depthseries.id,
@@ -69,10 +49,11 @@ class API(View):
                 )
                 .label("rn")
             )
+            .filter(Depthseries.value.isnot(None))
             .subquery()
         )
 
-        # Pick only the first fow
+        # Pick only the first row
         query = self.session.query(
             sub_query.c.id,
             sub_query.c.depth,
@@ -84,6 +65,6 @@ class API(View):
                 "id": str(q.id),
                 "depth": q.depth,
                 "value": q.value
-                }
+            }
                 for q in query.all()
-            ]
+        ]

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -7,6 +7,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 from pyramid_app_caseinterview.filters.services import get_filtered_query
+from pyramid_app_caseinterview.utils.file_writers import write_to_csv
 
 from sqlalchemy import func
 
@@ -25,6 +26,7 @@ class API(View):
     def timeseries_api(self):
         query = self.session.query(Timeseries)
 
+        # Apply URL query filter
         try:
             query = get_filtered_query(Timeseries,
                                        query,
@@ -70,7 +72,7 @@ class API(View):
             sub_query.c.id,
             sub_query.c.depth,
             sub_query.c.value
-        ).filter(sub_query.c.rn == 1)
+            ).filter(sub_query.c.rn == 1)
 
         return [
             {
@@ -80,3 +82,49 @@ class API(View):
             }
                 for q in query.all()
         ]
+    
+    # Download API endpoint
+    @view_config(
+        route_name="download_depthseries",
+        permission=NO_PERMISSION_REQUIRED,
+        request_method="GET"
+    )
+    def download_depthseries(self):
+        query = (
+            self.session.query(
+                Depthseries.id,
+                Depthseries.depth,
+                Depthseries.value,
+                func.row_number()
+                .over(
+                    partition_by=Depthseries.depth,
+                )
+                .label("rn")
+            )
+            .filter(Depthseries.value.isnot(None))
+        )
+
+        # Apply URL query filter
+        try:
+            query = get_filtered_query(Depthseries,
+                                       query,
+                                       self.request.GET,
+                                       filter_type="depthseries_depth_filter"
+                                    )
+        except ValueError as e:
+            raise HTTPBadRequest(json_body={"Error": str(e)})
+        
+        # Create sub query for duplication filtering
+        sub_query = query.subquery()
+
+        # Pick only the first row
+        query = self.session.query(
+            sub_query.c.id,
+            sub_query.c.depth,
+            sub_query.c.value
+            ).filter(sub_query.c.rn == 1)
+        
+        header = ["depth","value"]
+        response = write_to_csv(query, header, "depthseries.csv")
+        return response
+

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -2,9 +2,11 @@
 
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPBadRequest
 
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.filters.services import get_filtered_query
 
 from sqlalchemy import func
 
@@ -22,13 +24,23 @@ class API(View):
     )
     def timeseries_api(self):
         query = self.session.query(Timeseries)
+
+        try:
+            query = get_filtered_query(Timeseries,
+                                       query,
+                                       self.request.GET,
+                                       filter_type="timeseries_datetime_filter"
+                                    )
+            
+        except ValueError as e:
+            raise HTTPBadRequest(json_body={"Error": str(e)})
+
         return [
             {
                 "id": str(q.id),
                 "datetime": q.datetime.isoformat() if q.datetime else None,
                 "value": q.value,
-            }
-            for q in query.all()
+            }   for q in query.all()
         ]
 
     @view_config(

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": q.datetime.isoformat() if q.datetime else None,
                 "value": q.value,
             }
             for q in query.all()
@@ -36,12 +38,52 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        # ## API layer fixes for duplication problems
+        # # Option 1: By keeping only the first occurrence of each depth
+        # query = self.session.query(Depthseries)
+        # recorded_depths = set()
+        # cleaned_records = []
+        # for q in query.all():
+        #     if q.depth in recorded_depths:
+        #         continue 
+        #     recorded_depths.add(q.depth)
+        #     cleaned_records.append(
+        #         {
+        #             "id": str(q.id),
+        #             "depth": q.depth,
+        #             "value": q.value
+        #         }
+        #     )
+
+        # return cleaned_records
+    
+        # Option 2: By leveraging sqlalchemy functionalities at query time
+        sub_query = (
+            self.session.query(
+                Depthseries.id,
+                Depthseries.depth,
+                Depthseries.value,
+                func.row_number()
+                .over(
+                    partition_by=Depthseries.depth,
+                )
+                .label("rn")
+            )
+            .subquery()
+        )
+
+        # Pick only the first fow
+        query = self.session.query(
+            sub_query.c.id,
+            sub_query.c.depth,
+            sub_query.c.value
+        ).filter(sub_query.c.rn == 1)
+
         return [
             {
                 "id": str(q.id),
                 "depth": q.depth,
-                "value": q.value,
-            }
-            for q in query.all()
-        ]
+                "value": q.value
+                }
+                for q in query.all()
+            ]

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source .env.local.sh
+pserve development.ini --reload

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source .env.test.sh
+pytest tests/.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ paste.app_factory =
 
 console_scripts =
     pyramid_app_caseinterview_initialize_db = pyramid_app_caseinterview.scripts.initializedb:main
+    pyramid_app_caseinterview_generate_fake_data = pyramid_app_caseinterview.scripts.generate_fake_data:main
+    pyramid_app_caseinterview_ingest_depthseries_data = pyramid_app_caseinterview.scripts.ingest_data_depthseries:main
 
 [options]
 packages = find:
@@ -32,11 +34,11 @@ install_requires =
     docopt
     gunicorn
     pyramid
-    numpy==2.*
+    numpy>=1.26,<2.0
     sqlalchemy==2.*
     transaction
     mako
-    pandas==2.1.4
+    pandas
     pypugjs
     psycopg2-binary
     pyramid_debugtoolbar

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,53 +14,61 @@ INI_FILE = os.path.join(os.path.dirname(__file__), "testing.ini")
 SETTINGS = appconfig("config:" + INI_FILE)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def app():
     app = main({}, **SETTINGS)
     print("SETUP app")
-    from pyramid_app_caseinterview.scripts import initializedb
 
+    # Drop and recreate schema
+    from pyramid_app_caseinterview.scripts import initializedb
     initializedb.main([str(INI_FILE), "--drop-all"])
+
+    # Generate fake data for testing
+    from pyramid_app_caseinterview.scripts import generate_fake_data
+    generate_fake_data.main([str(INI_FILE), "--clear-data"])
+
     yield app
+
+    # Teardown: drop all tables at the very end of the tests
     print("TEARDOWN app")
     Base.metadata.drop_all(app.registry["session_factory"].kw["bind"])
     print("TEARDOWN app complete")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def engine(app):
     yield app.registry["session_factory"].kw["bind"]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def testapp(app):
     testapp = webtest.TestApp(app)
     yield testapp
     del testapp
 
 
-@pytest.fixture(scope="module")
-def session(app):
-    # session without transaction manager
-    session_factory = app.registry["session_factory"]
-    session = session_factory()
-    yield session
-    session.close()
+# @pytest.fixture(scope="module")
+# def session(app):
+#     """Session without transaction manager"""
+#     session_factory = app.registry["session_factory"]
+#     session = session_factory()
+#     yield session
+#     session.close()
 
 
 @pytest.fixture(scope="function")
 def session_tm(app):
-    """Transaction managed session with rolback."""
+    """Transaction managed session with rollback."""
     session_factory = app.registry["session_factory"]
     session = get_tm_session(session_factory, transaction.manager)
     yield session
     session.close()
 
 
-@pytest.fixture(scope="module")
-def session_tm_module_scope(app):
-    """Transaction managed session in module scope with rolback."""
-    session_factory = app.registry["session_factory"]
-    session = get_tm_session(session_factory, transaction.manager)
-    yield session
-    session.close()
+# @pytest.fixture(scope="module")
+# def session_tm_module_scope(app):
+#     """Transaction managed session in module scope with rolback."""
+#     session_factory = app.registry["session_factory"]
+#     session = get_tm_session(session_factory, transaction.manager)
+#     yield session
+#     session.close()

--- a/tests/test_api_timeseries.py
+++ b/tests/test_api_timeseries.py
@@ -1,0 +1,28 @@
+class TestTimeSeriesAPI:
+    def test_get_timeseries(self, testapp) -> None:
+        response = testapp.get("/api/v1/timeseries", status=200)
+        data = response.json
+        assert isinstance(data, list)
+        assert all(set(item.keys()) >= {"datetime", "value"} for item in data)
+        assert any(isinstance(item["value"], float) for item in data)
+    
+    def test_valid_date_filter_format(self, testapp) -> None:
+        response = testapp.get("/api/v1/timeseries?start_date=2025-08-19T22:34:13&end_date=2025-08-23T03:34:13", status=200)
+        data = response.json
+        assert isinstance(data,list)
+        assert all(set(item.keys()) >= {"datetime", "value"} for item in data)
+        assert any(isinstance(item["value"], float) for item in data)
+    
+    def test_valid_date_filter_format_out_of_bound(self, testapp) -> None:
+        response = testapp.get("/api/v1/timeseries?start_date=2100-08-19T22:34:13&end_date=2100-08-23T03:34:13", status=200)
+        data = response.json
+        assert data == []
+
+    def test_invalid_date_filter_format(self, testapp) -> None:
+        response = testapp.get("/api/v1/timeseries?start_date=2024-12-3x", status=400)
+        assert response.status_code == 400
+
+    def test_invalid_request(self, testapp) -> None:
+        response = testapp.get("/api/v1/timeseries_not_exist", status=404)
+        assert response.status_code == 404
+


### PR DESCRIPTION
# Ticket
9. PRODUCT BACKLOG ITEM 8293 – Depthseries API - Add endpoint to Download Data
as CSV

# Description
This feature allows users to download data from the API in CSV format. This is particularly useful for sharing or processing data in external tools like TextEditor or Excel.

# Implementation
For this feature, I introduced a new  `utils` package that serve utilities for multiple purpose including `file_writers.py` for this context that handles file writing. This approach ensures modularization and scalability for future development.

# Key Additions:
- Introduced `utils.py` package, with `file_writers.py` module for writing specific file requested by user through API download endpoint.
- Added new routes handling in `routes.py` to support data download through API endpoint.
- Implemented new API endpoint `/api/v1/download/depthseries`
- Developed filtering logic for the Depthseries data using start_depth and end_depth query parameters.

>[!CAUTION]
As you may notice, and also previously discussed in earlier PR, handling complex filtering directly within API layer, in this context using the SQLAlchemy functionalities, has made the codebase harder to manage. This implementation reflects that complexity.

# Changes Summary
- Implement new routes for Depthseries data download API endpoint with URL query parameter for filtering by depth field.
- Depthseries API endpoint serve the requested data in `.csv` file format.
